### PR TITLE
Update mfs-cgiserv.init

### DIFF
--- a/debian/mfs-cgiserv.init
+++ b/debian/mfs-cgiserv.init
@@ -44,7 +44,7 @@ set -e
 case "$1" in
 	start)
 		echo "Starting $DESC:"
-		start-stop-daemon --start -c $MFSCGISERV_USER:$MSGCGISERV_GROUP $DAEMON $DAEMON_OPTS start
+		start-stop-daemon --start -c $MFSCGISERV_USER:$MSGCGISERV_GROUP --exec $DAEMON $DAEMON_OPTS start
 		;;
 
 	stop)


### PR DESCRIPTION
In the ubuntu server 12.04 LTS,this script can not start,and when I start it by command "sudo service mfs-cgiserv start",the console message shows:
"start-stop-daemon: --start needs --exec or --startas
Try 'start-stop-daemon --help' for more information."
So,I find the "/etc/init.d/mfs-cgiserv" and modify that file,the problem is solved,I think it`s helpful !
